### PR TITLE
Modified logic to pass through all ext_journal data

### DIFF
--- a/splash/splashGen.rb
+++ b/splash/splashGen.rb
@@ -217,9 +217,12 @@ def splashInstrucs(itemID, item, attrs)
   elsif (ext = attrs["ext_journal"]) && ext["name"]
     # External journals
     journalText = ext["name"]
-    if ext["volume"]
+    if ext["volume"] && ext["issue"]
+      journalText << ", #{ext["volume"]}(#{ext["issue"]})"
+    elsif ext["volume"]
       journalText << ", #{ext["volume"]}"
-      ext["issue"] and journalText << "(#{ext["issue"]})"
+    elsif ext["issue"]
+      journalText << ", issue #{ext["issue"]}"
     end
     issn = ext["issn"]
   end


### PR DESCRIPTION
## Description of changes

eScholarship Journal Items must have both volume and issue data in order to update correctly.

However, non-eS. Journal items store journal-related data at the item level, in `items.attrs.ext_journal`, which can handle null values on any journal-related data (j. name, issn, volume, issue, fpage, lpage).

The following changes re-order the logic to _first_ identify if a publication is from an eS. journal, _then_ mandate issue & volume numbers if this is true.

Non-eS. journals now pass all of their Journal-related data.

## Testing status
- Deployed on staging 2025-08-18 and working as expected.
- This morning I spot-checked several Elements-side pubs marked as "Deleted" or "Withdrawn" -- these appear to be filtered out via the Relevance scheme, so unneccesary diff syncing for these pubs is unlikely.
- `erepdo convert qt1234` worked as expected for eS. journal items
- A rough count of Elements pubs having eSchol records but lacking either `volume` or `issue` data, but having other journal data, is around 37k. I would consider this an upper limit.