### PR TITLE
Harmonize genre for old and new ETDs

### DIFF
--- a/tools/convert.rb
+++ b/tools/convert.rb
@@ -1261,7 +1261,7 @@ def parseUCIngest(itemID, inMeta, fileType, isPending)
                            dbItem[:content_type].nil? &&
                            attrs[:supp_files]) ? "multimedia" :
                           fileType == "ETD" ? "dissertation" :
-                          inMeta[:type] ? inMeta[:type].sub("paper", "article") :
+                          inMeta[:type] ? inMeta[:type].sub("paper", "article").sub("etd","dissertation"):
                           "article"
   dbItem[:submitted]    = submissionDate
   dbItem[:added]        = addDate


### PR DESCRIPTION
The new ETD  have type 'etd' and the same string is carried as genre. The old ETDs have genre 'dissertation' for ProQuest file parsing logic. Harmonizing the genre to prevent downstream changes in UI and splash gen. 